### PR TITLE
As of dogapi v1.14.0, it doesn't support String keys in options

### DIFF
--- a/lib/fluent/plugin/out_datadog.rb
+++ b/lib/fluent/plugin/out_datadog.rb
@@ -84,9 +84,9 @@ class Fluent::DatadogOutput < Fluent::BufferedOutput
       end
 
       options = {}
-      options['tags'] = [tag] if tag
-      options['host'] = host if host
-      options['type'] = type if type
+      options[:tags] = [tag] if tag
+      options[:host] = host if host
+      options[:type] = type if type
 
       @dog.emit_points(metric, points, options)
     }


### PR DESCRIPTION
dogapi v1.14.0 only uses symbol keys in options. Passing tags via string key will just be ignored.

https://github.com/DataDog/dogapi-rb/blob/v1.14.0/lib/dogapi/v1/metric.rb#L74